### PR TITLE
Fixed a compilation error by not passing a function pointer to a template, which ignores attributes, but instead passing a struct which aims to do the same.

### DIFF
--- a/src/pushswap.cpp
+++ b/src/pushswap.cpp
@@ -9,13 +9,19 @@
 PushSwap::PushSwap() : path{"../../push_swap"} {}
 PushSwap::~PushSwap() {}
 
+struct closer {
+	int operator()(FILE *f) const {
+		return pclose(f);
+	}
+};
+
 void PushSwap::run(const std::string &numbers) {
   this->commands.clear();
   std::array<char, 128> buffer;
   std::string result;
   std::string command = this->path + " " + numbers;
-  std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(command.c_str(), "r"),
-                                                pclose);
+  std::unique_ptr<FILE, closer> pipe(popen(command.c_str(), "r"));
+                                                
 
   if (!pipe) {
     throw std::runtime_error("popen() failed!");


### PR DESCRIPTION
https://stackoverflow.com/a/76867913

My changes are fully based on this answer being correct. Which to little of my knowledge it seemingly is so. All I know for certain it compiles with the newer C++ versions. It also works as good as before. Although no more testing than standard use has been performed.